### PR TITLE
Make collections have id_count instead of one global id_count

### DIFF
--- a/engine-core/src/db/collection.rs
+++ b/engine-core/src/db/collection.rs
@@ -73,7 +73,9 @@ impl From<&str> for CollectionDto {
 /// Checks if a collection exists in a database.
 pub fn collection_exists(db: &pb::Database, collection_name: &str) -> bool {
     for collection in db.collections() {
-        return collection.name() == collection_name
+        if collection.name() == collection_name {
+            return true;
+        }
     }
 
     false

--- a/engine-core/src/db/collection.rs
+++ b/engine-core/src/db/collection.rs
@@ -30,6 +30,10 @@ impl pb::Collection {
     pub fn documents_mut(&mut self) -> &mut Vec<pb::Document> {
         &mut self.documents
     }
+
+    pub fn id_count(&self) -> &u64 {
+        &self.id_count
+    }
 }
 
 impl From<&str> for pb::Collection {
@@ -37,6 +41,7 @@ impl From<&str> for pb::Collection {
         Self {
             name: String::from(name),
             documents: Vec::new(),
+            id_count: 0,
         }
     }
 }

--- a/engine-core/src/db/database.rs
+++ b/engine-core/src/db/database.rs
@@ -31,10 +31,6 @@ impl pb::Database {
     pub fn collections_mut(&mut self) -> &mut Vec<pb::Collection> {
         &mut self.collections
     }
-
-    pub fn id_count(&self) -> &u64 {
-        &self.id_count
-    }
 }
 
 impl From<&str> for pb::Database {
@@ -43,7 +39,6 @@ impl From<&str> for pb::Database {
             name: String::from(name),
             description: String::new(),
             collections: Vec::new(),
-            id_count: 0,
         }
     }
 }
@@ -54,7 +49,6 @@ impl From<(&str, &str)> for pb::Database {
             name: String::from(name),
             description: String::from(description),
             collections: Vec::new(),
-            id_count: 0,
         }
     }
 }

--- a/engine-core/src/db/document.rs
+++ b/engine-core/src/db/document.rs
@@ -36,10 +36,10 @@ impl pb::Document {
     /// Creates a new document.
     /// 
     /// Increments the database's `id_count` by 1 so each document gets a unique id.
-    pub fn new(database: &mut pb::Database) -> Self {
-        database.id_count += 1;
+    pub fn new(collection: &mut pb::Collection) -> Self {
+        collection.id_count += 1;
         Self {
-            id: database.id_count,
+            id: collection.id_count,
             data: HashMap::new(),
         }
     }
@@ -154,13 +154,13 @@ pub fn create_document_to_db_file(
     }
 
     if let Some(collection_index) = collection_index {
-        let mut document = pb::Document::new(&mut database);
-        document.data = data;
-
         if let Some(collection) = database
             .collections_mut()
             .get_mut(collection_index)
         {
+            let mut document = pb::Document::new(collection);
+            document.data = data;
+
             collection.documents_mut().push(document);
             let buf = serialize_database(&database)?;
 

--- a/engine-core/src/proto/database.proto
+++ b/engine-core/src/proto/database.proto
@@ -7,12 +7,12 @@ message Database {
     string name = 1;
     string description = 2;
     repeated Collection collections = 3;
-    uint64 id_count = 4;
 }
 
 message Collection {
-    string name = 1;
-    repeated Document documents = 2;
+    uint64 id_count = 1;
+    string name = 2;
+    repeated Document documents = 3;
 }
 
 message Document {


### PR DESCRIPTION
- Database no longer has global id_count
- Each collection now has its own id_count so document IDs are unique to the collection