### PR TITLE
Database and document display traits

### DIFF
--- a/engine/src/storage/database.rs
+++ b/engine/src/storage/database.rs
@@ -5,7 +5,8 @@ use std::{
         Path,
         PathBuf,
     },
-    error::Error, fmt::Display,
+    error::Error,
+    fmt::Display,
 };
 use crate::storage::{
     error::DatabaseError,

--- a/engine/src/storage/database.rs
+++ b/engine/src/storage/database.rs
@@ -5,7 +5,7 @@ use std::{
         Path,
         PathBuf,
     },
-    error::Error,
+    error::Error, fmt::Display,
 };
 use crate::storage::{
     error::DatabaseError,
@@ -110,6 +110,23 @@ impl DatabaseDto {
             size,
             file_path,
         }
+    }
+}
+
+impl Display for DatabaseDto {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "
+  Name:        {}
+  Size:        {} bytes
+  Description: {}
+  File path:   {}",
+            self.name(),
+            self.size(),
+            self.description(),
+            self.file_path().display(),
+        )
     }
 }
 

--- a/engine/src/storage/document.rs
+++ b/engine/src/storage/document.rs
@@ -4,20 +4,24 @@ use std::{
     path::Path,
     error::Error,
     collections::HashMap,
-    fmt,
+    fmt::{self, Display},
 };
-use crate::storage::{
-    error::{
-        DatabaseError,
-        CollectionError,
-        DocumentError,
+use crate::{
+    DocumentInputDataField,
+    storage::{
+        error::{
+            DatabaseError,
+            CollectionError,
+            DocumentError,
+        },
+        pb,
+        pb::document::DataType,
+        pb::document::data_type,
+        serialize_database,
+        deserialize_database,
+        write_database_to_file,
+        DB_FILE_EXTENSION,
     },
-    pb,
-    pb::document::DataType,
-    serialize_database,
-    deserialize_database,
-    write_database_to_file,
-    DB_FILE_EXTENSION,
 };
 
 // Implements methods for protobuf type
@@ -83,7 +87,33 @@ impl DocumentDto {
     }
 }
 
-/* Disabled for now
+impl Display for DocumentDto {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut data = Vec::new();
+        for (key, value) in self.data().iter() {
+            // Get data type and value
+            let (data_type, field_value) = match &value.data_type {
+                Some(data_type::DataType::Int32(value)) => ("Int32", value.to_string()),
+                Some(data_type::DataType::Int64(value)) => ("Int64", value.to_string()),
+                Some(data_type::DataType::Decimal(value)) => ("Decimal", value.to_string()),
+                Some(data_type::DataType::Bool(value)) => ("Bool", value.to_string()),
+                Some(data_type::DataType::Text(value)) => ("Text", format!("\"{}\"", value)),
+                _ => ("Invalid document data type", "Invalid value".to_string()),
+            };
+    
+            data.push(format!("  [{}] \"{}\": {}", data_type, key, field_value));
+        }
+
+        write!(
+            f,
+            "{{\n  [DocumentId] _id: {}\n{}\n}}",
+            self.id(),
+            data.join("\n"),
+        )
+    }
+}
+
+/* Disabled for now. Currently defined in generated protocol buffers code.
 /// Data type for document fields
 #[derive(Debug, PartialEq, Clone)]
 pub enum DataType {

--- a/shell/src/database.rs
+++ b/shell/src/database.rs
@@ -11,7 +11,6 @@ use crate::{
     event_log_failed,
     error_log_failed,
 };
-use engine::storage::database::DatabaseDto;
 
 /// Display text that tells there is no connected database.
 pub const NO_CONNECTED_DB: &str = "No connected database";
@@ -39,19 +38,6 @@ impl ConnectedDatabase {
             file_path: PathBuf::from(file_path),
         }
     }
-}
-
-fn print_database_details(database: &DatabaseDto) {
-    println!(
-"
-  Name:        {}
-  Size:        {} bytes
-  Description: {}
-  File path:   {}",
-    database.name(),
-    database.size(),
-    database.description(),
-    database.file_path().display());
 }
 
 impl Cli {
@@ -258,8 +244,8 @@ impl Cli {
             if let Some(databases) = result.data {
                 println!("Number of databases: {}", databases.len());
 
-                for database in databases {
-                    print_database_details(&database);
+                for db in databases {
+                    println!("{}", &db);
                 }
             }
         } else {
@@ -286,7 +272,7 @@ impl Cli {
 
             if let Some(db) = result.data {
                 if let Some(db) = db {
-                    print_database_details(&db);
+                    println!("{}", &db);
                 } else {
                     println!("Database was not found");
                 }

--- a/shell/src/document.rs
+++ b/shell/src/document.rs
@@ -7,32 +7,7 @@ use crate::{
     event_log_failed,
     error_log_failed,
 };
-use engine::{
-    storage::{
-        pb::document::data_type::DataType,
-        document::DocumentDto,
-    },
-    DocumentInputDataField,
-};
-
-/// Displays document in a more readable format.
-fn display_document(document: &DocumentDto) {
-    println!("{}\n  [DocumentId] _id: {}", "{", document.id());
-    for (key, value) in document.data().iter() {
-        // Get data type and value
-        let (data_type, field_value) = match &value.data_type {
-            Some(DataType::Int32(value)) => ("Int32", value.to_string()),
-            Some(DataType::Int64(value)) => ("Int64", value.to_string()),
-            Some(DataType::Decimal(value)) => ("Decimal", value.to_string()),
-            Some(DataType::Bool(value)) => ("Bool", value.to_string()),
-            Some(DataType::Text(value)) => ("Text", format!("\"{}\"", value)),
-            _ => return eprintln!("Invalid document data type"),
-        };
-
-        println!("  [{data_type}] \"{key}\": {field_value}");
-    }
-    println!("{}", "}");
-}
+use engine::DocumentInputDataField;
 
 impl Cli {
     /// Show menu to create a new document to a collection.
@@ -227,7 +202,7 @@ impl Cli {
                 println!("Number of documents: {}", documents.len());
 
                 for document in documents {
-                    display_document(&document);
+                    println!("{}", &document);
                 }
             }
         } else {
@@ -268,7 +243,7 @@ impl Cli {
                 println!("Number of documents: {}", documents.len());
 
                 for document in documents {
-                    display_document(&document);
+                    println!("{}", &document);
                 }
             }
         } else {
@@ -307,7 +282,7 @@ impl Cli {
 
             if let Some(data) = result.data {
                 if let Some(document) = data {
-                    display_document(&document);
+                    println!("{}", &document);
                 } else {
                     println!("Document with this ID was not found");
                 }


### PR DESCRIPTION
This adds Display traits for `engine` structs
- `DatabaseDto`
- `DocumentDto`

Also removes database and document display functions from `shell` by replacing them with the usage of the display traits.