### PR TITLE
Find documents with limit + tests

### DIFF
--- a/driver/src/collection.rs
+++ b/driver/src/collection.rs
@@ -58,7 +58,7 @@ impl<'a> Collection<'a> {
     pub fn find_all(&self) -> Result<Vec<DocumentModel>, DatabaseClientError> {
         let result = self.client.engine
             .storage_api()
-            .find_all_documents(self.database.connection_string(), self.name());
+            .find_all_documents(self.database.connection_string(), self.name(), None);
 
         if let Some(e) = result.error {
             return Err(DatabaseClientError::new(
@@ -94,7 +94,7 @@ impl<'a> Collection<'a> {
         let query = transform_document_data_to_input(&query.data);
         let result = self.client.engine
             .storage_api()
-            .find_documents(self.database.connection_string(), self.name(), &query);
+            .find_documents(self.database.connection_string(), self.name(), &query, None);
 
         if let Some(e) = result.error {
             return Err(DatabaseClientError::new(

--- a/engine/src/storage/api.rs
+++ b/engine/src/storage/api.rs
@@ -578,9 +578,10 @@ impl StorageApi {
         &self,
         db_file_path: &Path,
         collection_name: &str,
+        limit: Option<usize>,
     ) -> StorageRequestResult<Vec<DocumentDto>>
     {
-        match self.db_manager.find_all_documents(db_file_path, collection_name) {
+        match self.db_manager.find_all_documents(db_file_path, collection_name, limit) {
             Ok(documents) => {
                 let content = format!(
                     "Fetched all documents from collection '{}' in database '{}'",
@@ -696,9 +697,10 @@ impl StorageApi {
         db_file_path: &Path,
         collection_name: &str,
         query: &Vec<DocumentInputDataField>,
+        limit: Option<usize>
     ) -> StorageRequestResult<Vec<DocumentDto>>
     {
-        match self.db_manager.find_documents(db_file_path, collection_name, query) {
+        match self.db_manager.find_documents(db_file_path, collection_name, query, limit) {
             Ok(documents) => {
                 let content = format!(
                     "Fetched {} documents from collection '{}' in database '{}'",

--- a/engine/src/storage/db_manager.rs
+++ b/engine/src/storage/db_manager.rs
@@ -434,11 +434,13 @@ impl DatabaseManager {
         &self,
         db_file_path: &Path,
         collection_name: &str,
+        limit: Option<usize>,
     ) -> Result<Vec<DocumentDto>, DatabaseOperationError>
     {
         match find_all_documents_in_collection(
             db_file_path,
-            collection_name
+            collection_name,
+            limit,
         ) {
             Ok(documents) => return Ok(documents),
             Err(err) => return Err(DatabaseOperationError::new(
@@ -496,6 +498,7 @@ impl DatabaseManager {
         db_file_path: &Path,
         collection_name: &str,
         query: &Vec<DocumentInputDataField>,
+        limit: Option<usize>,
     ) -> Result<Vec<DocumentDto>, DatabaseOperationError>
     {
         let mut transformed_query: HashMap<String, data_type::DataType> = HashMap::new();
@@ -524,7 +527,8 @@ impl DatabaseManager {
         match find_documents_in_collection(
             db_file_path,
             collection_name,
-            &transformed_query
+            &transformed_query,
+            limit,
         ) {
             Ok(documents) => return Ok(documents),
             Err(err) => return Err(DatabaseOperationError::new(

--- a/engine/tests/document/delete_document.rs
+++ b/engine/tests/document/delete_document.rs
@@ -80,7 +80,7 @@ fn delete_all_documents_success() {
     }
 
     let result = engine.storage_api()
-        .find_all_documents(&file_path, collection_name);
+        .find_all_documents(&file_path, collection_name, None);
     let document_count = result.data.unwrap().len();
     assert!(document_count > 0);
 
@@ -92,7 +92,7 @@ fn delete_all_documents_success() {
     assert_eq!(result.data.unwrap(), document_count);
 
     let result = engine.storage_api()
-        .find_all_documents(&file_path, collection_name);
+        .find_all_documents(&file_path, collection_name, None);
     assert_eq!(result.data.unwrap().len(), 0);
 
     config_settings.close_temp_dirs();

--- a/engine/tests/document/find_document.rs
+++ b/engine/tests/document/find_document.rs
@@ -37,7 +37,7 @@ fn find_all_documents_success() {
     let document = result.data.unwrap();
     let result = engine
         .storage_api()
-        .find_all_documents(&file_path, collection_name);
+        .find_all_documents(&file_path, collection_name, None);
     assert!(result.success);
     assert!(result.data.is_some());
     assert!(result.error.is_none());
@@ -128,7 +128,7 @@ fn find_documents_success() {
     
     let result = engine
         .storage_api()
-        .find_documents(&file_path, collection_name, &query);
+        .find_documents(&file_path, collection_name, &query, None);
     assert!(result.success);
     assert!(result.data.is_some());
     assert!(result.error.is_none());

--- a/shell/src/document.rs
+++ b/shell/src/document.rs
@@ -236,7 +236,7 @@ impl Cli {
         };
         let result = self.engine
             .storage_api()
-            .find_all_documents(connected_db.file_path(), &collection_name);
+            .find_all_documents(connected_db.file_path(), &collection_name, None);
 
         if result.success {
             event_log_failed(result.log_error);
@@ -380,7 +380,7 @@ impl Cli {
 
         let result = self.engine
             .storage_api()
-            .find_documents(connected_db.file_path(), &collection_name, &query);
+            .find_documents(connected_db.file_path(), &collection_name, &query, None);
 
         if result.success {
             event_log_failed(result.log_error);


### PR DESCRIPTION
This adds the feature to specify limit when finding all documents or using query. Limit specifies the maximum number of returned documents.

Tests included.