### PR TITLE
Driver DocumentQueryOptions

### DIFF
--- a/driver/src/collection.rs
+++ b/driver/src/collection.rs
@@ -22,7 +22,7 @@ use crate::{
         DocumentModel,
         DataType,
         DocumentId,
-        DocumentQuery,
+        DocumentQuery, DocumentQueryOptions,
     },
 };
 
@@ -55,10 +55,18 @@ impl<'a> Collection<'a> {
     /// Finds all documents in this collection.
     /// 
     /// Returns the found documents.
-    pub fn find_all(&self) -> Result<Vec<DocumentModel>, DatabaseClientError> {
+    pub fn find_all(
+        &self,
+        options: &Option<DocumentQueryOptions>,
+    ) -> Result<Vec<DocumentModel>, DatabaseClientError> {
+        let mut limit = None;
+        if let Some(options) = options {
+            limit = options.limit;
+        }
+
         let result = self.client.engine
             .storage_api()
-            .find_all_documents(self.database.connection_string(), self.name(), None);
+            .find_all_documents(self.database.connection_string(), self.name(), limit);
 
         if let Some(e) = result.error {
             return Err(DatabaseClientError::new(
@@ -90,11 +98,20 @@ impl<'a> Collection<'a> {
     /// Query contains fields with values that the document needs to match.
     /// 
     /// Returns the found documents.
-    pub fn find_many(&self, query: &DocumentQuery) -> Result<Vec<DocumentModel>, DatabaseClientError> {
+    pub fn find_many(
+        &self,
+        query: &DocumentQuery,
+        options: &Option<DocumentQueryOptions>,
+    ) -> Result<Vec<DocumentModel>, DatabaseClientError> {
+        let mut limit = None;
+        if let Some(options) = options {
+            limit = options.limit;
+        }
         let query = transform_document_data_to_input(&query.data);
+
         let result = self.client.engine
             .storage_api()
-            .find_documents(self.database.connection_string(), self.name(), &query, None);
+            .find_documents(self.database.connection_string(), self.name(), &query, limit);
 
         if let Some(e) = result.error {
             return Err(DatabaseClientError::new(

--- a/driver/src/collection.rs
+++ b/driver/src/collection.rs
@@ -22,7 +22,8 @@ use crate::{
         DocumentModel,
         DataType,
         DocumentId,
-        DocumentQuery, DocumentQueryOptions,
+        DocumentQuery,
+        DocumentQueryOptions,
     },
 };
 
@@ -57,7 +58,7 @@ impl<'a> Collection<'a> {
     /// Returns the found documents.
     pub fn find_all(
         &self,
-        options: &Option<DocumentQueryOptions>,
+        options: Option<&DocumentQueryOptions>,
     ) -> Result<Vec<DocumentModel>, DatabaseClientError> {
         let mut limit = None;
         if let Some(options) = options {
@@ -101,7 +102,7 @@ impl<'a> Collection<'a> {
     pub fn find_many(
         &self,
         query: &DocumentQuery,
-        options: &Option<DocumentQueryOptions>,
+        options: Option<&DocumentQueryOptions>,
     ) -> Result<Vec<DocumentModel>, DatabaseClientError> {
         let mut limit = None;
         if let Some(options) = options {

--- a/driver/src/document.rs
+++ b/driver/src/document.rs
@@ -81,3 +81,15 @@ impl DocumentQuery {
         DocumentQuery { data: HashMap::new() }
     }
 }
+
+/// Options to include in queries.
+pub struct DocumentQueryOptions {
+    /// Maximum number of documents to return.
+    pub limit: Option<usize>,
+}
+
+impl DocumentQueryOptions {
+    pub fn new(limit: Option<usize>) -> DocumentQueryOptions {
+        DocumentQueryOptions { limit }
+    }
+}

--- a/driver/tests/collection/delete.rs
+++ b/driver/tests/collection/delete.rs
@@ -49,13 +49,13 @@ pub fn delete_all_documents_success() {
     for _ in 0..3 {
         assert!(collection.insert_one(create_test_document()).is_ok());
     }
-    let documents = collection.find_all().unwrap();
+    let documents = collection.find_all(&None).unwrap();
     assert!(documents.len() > 0);
 
     let deleted_count = collection.delete_all().unwrap();
     assert_eq!(documents.len(), deleted_count);
 
-    let documents = collection.find_all().unwrap();
+    let documents = collection.find_all(&None).unwrap();
     assert!(documents.is_empty());
 
     config.close_temp_dirs();

--- a/driver/tests/collection/delete.rs
+++ b/driver/tests/collection/delete.rs
@@ -49,13 +49,13 @@ pub fn delete_all_documents_success() {
     for _ in 0..3 {
         assert!(collection.insert_one(create_test_document()).is_ok());
     }
-    let documents = collection.find_all(&None).unwrap();
+    let documents = collection.find_all(None).unwrap();
     assert!(documents.len() > 0);
 
     let deleted_count = collection.delete_all().unwrap();
     assert_eq!(documents.len(), deleted_count);
 
-    let documents = collection.find_all(&None).unwrap();
+    let documents = collection.find_all(None).unwrap();
     assert!(documents.is_empty());
 
     config.close_temp_dirs();

--- a/driver/tests/collection/find.rs
+++ b/driver/tests/collection/find.rs
@@ -28,7 +28,7 @@ pub fn find_all_documents_success() {
     let collection = database.get_collection(collection_name).unwrap();
     let document = create_test_document();
     let created_document = collection.insert_one(document).unwrap();
-    let found_documents = collection.find_all().unwrap();
+    let found_documents = collection.find_all(&None).unwrap();
 
     assert_eq!(found_documents.len(), 1);
     assert_eq!(found_documents.first().unwrap().id.0, created_document.id.0);
@@ -67,7 +67,7 @@ pub fn find_documents_success() {
 
     let mut query = DocumentQuery::new();
     query.data.insert("age".to_string(), DataType::Int32(35));
-    let found_documents = collection.find_many(&query).unwrap();
+    let found_documents = collection.find_many(&query, &None).unwrap();
 
     assert!(found_documents.len() > 0);
     assert_eq!(found_documents.len(), expected_document_count);

--- a/examples/bookstore/src/main.rs
+++ b/examples/bookstore/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
                 },
                 Some(BookCommands::FindAll(_args)) => {
                     let books = book_db_context.book_collection
-                        .find_all(&None)
+                        .find_all(None)
                         .unwrap();
 
                     println!("Books found: {}", books.len());

--- a/examples/bookstore/src/main.rs
+++ b/examples/bookstore/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
                 },
                 Some(BookCommands::FindAll(_args)) => {
                     let books = book_db_context.book_collection
-                        .find_all()
+                        .find_all(&None)
                         .unwrap();
 
                     println!("Books found: {}", books.len());

--- a/examples/driver-test/src/lib.rs
+++ b/examples/driver-test/src/lib.rs
@@ -68,7 +68,7 @@ pub fn run() {
         println!("Document not found");
     }
 
-    let people = people_collection.find_all(&None).unwrap();
+    let people = people_collection.find_all(None).unwrap();
 
     println!("\nAll documents");
     println!("-------------");

--- a/examples/driver-test/src/lib.rs
+++ b/examples/driver-test/src/lib.rs
@@ -68,7 +68,7 @@ pub fn run() {
         println!("Document not found");
     }
 
-    let people = people_collection.find_all().unwrap();
+    let people = people_collection.find_all(&None).unwrap();
 
     println!("\nAll documents");
     println!("-------------");


### PR DESCRIPTION
This adds `DocumentQueryOptions` to database driver. It is used in collection API document find methods to specify limit. 